### PR TITLE
Grid Class

### DIFF
--- a/bot_1/lib/bot_saves_princess.rb
+++ b/bot_1/lib/bot_saves_princess.rb
@@ -1,26 +1,13 @@
+require_relative 'grid'
+
 class BotSavesPrincess
   attr_reader :size, 
               :grid
 
-  def initialize(size, grid)
-    @size              = size
-    @grid              = grid
-    @bot_location      = locate_character_location("m")
-    @princess_location = locate_character_location("p")
-  end
-
-  # iterates over each row of the grid checking for the desired character
-  # returns two index array representing the vertical and horizontal location of character
-  def locate_character_location(character)
-    location = []
-
-    @grid.each_with_index do |element, index|
-      if element.include?(character)
-        location << index
-        location << (element.chars.find_index(character))
-      end
-    end
-    location
+  def initialize(grid)
+    @grid              = grid.grid
+    @bot_location      = grid.bot_location
+    @princess_location = grid.princess_location
   end
 
   # returns two index array representing the difference between the shared indexes

--- a/bot_1/lib/grid.rb
+++ b/bot_1/lib/grid.rb
@@ -1,0 +1,28 @@
+class Grid
+  attr_reader :size, 
+              :grid,
+              :bot_location,
+              :princess_location
+
+
+  def initialize(size, grid)
+    @size              = size
+    @grid              = grid
+    @bot_location      = locate_character_location("m")
+    @princess_location = locate_character_location("p")
+  end
+
+  # iterates over each row of the grid checking for the desired character
+  # returns two index array representing the vertical and horizontal location of character
+  def locate_character_location(character)
+    location = []
+
+    @grid.each_with_index do |element, index|
+      if element.include?(character)
+        location << index
+        location << (element.chars.find_index(character))
+      end
+    end
+    location
+  end
+end

--- a/bot_1/spec/bot_saves_princess_spec.rb
+++ b/bot_1/spec/bot_saves_princess_spec.rb
@@ -1,15 +1,13 @@
+require './lib/grid'
 require './lib/bot_saves_princess'
 
 RSpec.describe BotSavesPrincess do 
-  context 'initialize' do 
-    let(:bsp) {BotSavesPrincess.new(3, ["---", "-m-", "p--"])}
+  context 'initialize' do
+    let(:grid) {Grid.new(3, ["---", "-m-", "p--"])}
+    let(:bsp) {BotSavesPrincess.new(grid)}
 
     it 'exists' do
       expect(bsp).to be_a(BotSavesPrincess)
-    end
-
-    it 'has a size attribute' do
-      expect(bsp.size).to eq(3)
     end
 
     it 'has a grid attribute' do
@@ -18,9 +16,12 @@ RSpec.describe BotSavesPrincess do
   end
 
   context 'determine_character_location_differences' do
-    let(:bsp_1) {BotSavesPrincess.new(3, ["---", "-m-", "p--"])}
-    let(:bsp_2) {BotSavesPrincess.new(3, ["--p", "-m-", "---"])}
-    let(:bsp_3) {BotSavesPrincess.new(5, ["-p---", "-----","--m--", "-----", "-----"])}
+    let(:grid_1) {Grid.new(3, ["---", "-m-", "p--"])}
+    let(:grid_2) {Grid.new(3, ["--p", "-m-", "---"])}
+    let(:grid_3) {Grid.new(5, ["-p---", "-----","--m--", "-----", "-----"])}
+    let(:bsp_1) {BotSavesPrincess.new(grid_1)}
+    let(:bsp_2) {BotSavesPrincess.new(grid_2)}
+    let(:bsp_3) {BotSavesPrincess.new(grid_3)}
 
     it 'can determine the differences between the character locations 3x3 grid' do
       expect(bsp_1.determine_character_location_differences).to eq([-1, 1])
@@ -33,9 +34,12 @@ RSpec.describe BotSavesPrincess do
   end
 
   context 'path to princess' do
-    let(:bsp_1) {BotSavesPrincess.new(3, ["---", "-m-", "p--"])}
-    let(:bsp_2) {BotSavesPrincess.new(3, ["--p", "-m-", "---"])}
-    let(:bsp_3) {BotSavesPrincess.new(5, ["-p---", "-----","--m--", "-----", "-----"])}
+    let(:grid_1) {Grid.new(3, ["---", "-m-", "p--"])}
+    let(:grid_2) {Grid.new(3, ["--p", "-m-", "---"])}
+    let(:grid_3) {Grid.new(5, ["-p---", "-----","--m--", "-----", "-----"])}
+    let(:bsp_1) {BotSavesPrincess.new(grid_1)}
+    let(:bsp_2) {BotSavesPrincess.new(grid_2)}
+    let(:bsp_3) {BotSavesPrincess.new(grid_3)}
 
     it 'can decipher path to princess 3x3 grid' do
       expect(bsp_1.display_path_to_princess).to eq(["DOWN", "LEFT"])

--- a/bot_1/spec/bot_saves_princess_spec.rb
+++ b/bot_1/spec/bot_saves_princess_spec.rb
@@ -17,18 +17,6 @@ RSpec.describe BotSavesPrincess do
     end
   end
 
-  context 'locate_character_location' do
-    let(:bsp) {BotSavesPrincess.new(3, ["---", "-m-", "p--"])}
-
-    it 'can locate the princess' do
-      expect(bsp.locate_character_location("p")).to eq([2, 0])
-    end
-
-    it 'can locate the bot' do
-      expect(bsp.locate_character_location("m")).to eq([1, 1])
-    end
-  end
-
   context 'determine_character_location_differences' do
     let(:bsp_1) {BotSavesPrincess.new(3, ["---", "-m-", "p--"])}
     let(:bsp_2) {BotSavesPrincess.new(3, ["--p", "-m-", "---"])}

--- a/bot_1/spec/grid_spec.rb
+++ b/bot_1/spec/grid_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe Grid do
     it 'has a grid attribute' do
       expect(grid.grid).to eq(["---", "-m-", "p--"])
     end
+
+    it 'has a bot location attribute' do 
+      expect(grid.bot_location).to eq([1, 1])
+    end
+
+    it 'has a princess location attribute' do 
+      expect(grid.princess_location).to eq([2, 0])
+    end
   end
 
   context 'locate_character_location' do

--- a/bot_1/spec/grid_spec.rb
+++ b/bot_1/spec/grid_spec.rb
@@ -1,0 +1,40 @@
+require "./lib/grid"
+
+RSpec.describe Grid do
+  context 'initialize' do 
+    let(:grid) {Grid.new(3, ["---", "-m-", "p--"])}
+
+    it 'exists' do
+      expect(grid).to be_a(Grid)
+    end
+    
+    it 'has a size attribute' do
+      expect(grid.size).to eq(3)
+    end
+
+    it 'has a grid attribute' do
+      expect(grid.grid).to eq(["---", "-m-", "p--"])
+    end
+  end
+
+  context 'locate_character_location' do
+    let(:grid) {Grid.new(3, ["---", "-m-", "p--"])}
+    let(:grid_2) {Grid.new(5, ["-p---", "-----","--m--", "-----", "-----"])}
+
+    it 'can locate the princess 3x3 grid' do
+      expect(grid.locate_character_location("p")).to eq([2, 0])
+    end
+
+    it 'can locate the bot 3x3 grid' do
+      expect(grid.locate_character_location("m")).to eq([1, 1])
+    end
+
+    it 'can locate the princess 5x5 grid' do
+      expect(grid_2.locate_character_location("p")).to eq([0, 1])
+    end
+
+    it 'can locate the bot 5x5 grid' do
+      expect(grid_2.locate_character_location("m")).to eq([2, 2])
+    end
+  end
+end


### PR DESCRIPTION
# Overview 
This pull request breaks the grid specific logic out of the `BotSavesPrincess` class and into its own class. None of the logic in this PR is new, but it is reorganized to display better OOP principles. The `BotSavesPrincess` class now inherits the functionality from Grid, and only accepts one argument, which is an instantiated Grid class. The Grid now accepts the size, and the grid array. 

# Testing 
The original grid tests from `bot_saves_princess_spec.rb` were moved into the new file `grid_spec.rb`. There were attribute tests removed from `bot_saves_princess_spec.rb` and the the scaffolding for the tests in `bot_saves_princess_spec.rb` was also updated.