### PR TITLE
Add circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/configuration-reference
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: cimg/ruby:3.3.1
+    steps:
+      - checkout
+      - run: ruby --version
+
+  test:
+    docker:
+      - image: cimg/ruby:3.3.1
+    steps: 
+      - checkout
+      - run: 
+          name: Gem Install
+          command: bundle install
+      - run:
+          name: Running Tests 
+          command: bundle exec rspec spec
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+      - test

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,26 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.5.1)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
+
+PLATFORMS
+  x86_64-darwin-20
+
+DEPENDENCIES
+  rspec
+
+BUNDLED WITH
+   2.2.33


### PR DESCRIPTION
# Overview 
This pull request adds a `Gemfile` (and `Gemfile.lock` from running `bundle install`) as well as CircleCi, and the `config.yml` file with the Ruby Docker Image `image: cimg/ruby:3.3.1` from the CircleCi docs. The config.yml file also contains all of the logic to handle the build, and to run the test suite when a pull request is opened for this repository. 

# Testing 
No additional testing aside from the CircleCi automated testing of the existing test suite. 